### PR TITLE
Setup continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+sudo: false
+cache: bundler
+
+before_install: gem install bundler
+
+rvm:
+  - 2.5

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,8 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
-task :default => :spec
+desc "Default: Excludes 'live' tests that issue real network calls."
+task default: %w(spec:quick)
 
 require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|


### PR DESCRIPTION
Summary:
This adds a travis configuration file with the intent that running the
application's test suite will become automatic each time a PR is
issued or a code change is pushed.

There are "live" specs that issue real network calls. To avoid these
network calls from being made each time the test suite is run, I've
configured the rake default to exclude the specs in the "live" directory.

I had hoped to address the failing tests before configuring automatic
tests. That goal has proven to take longer than I had hoped, so in the
interest of time, I'm moving forward with adding Travis as I'd rather
know about the test failures vs be unaware.